### PR TITLE
Change image tag source to release tag

### DIFF
--- a/.github/workflows/create-prod-snapshot-on-release.yml
+++ b/.github/workflows/create-prod-snapshot-on-release.yml
@@ -9,7 +9,7 @@ jobs:
   create_prod_snapshot:
     runs-on: ubuntu-latest
     env:
-      PKR_VAR_image_tag: prod-${{ github.event.pull_request.number }}
+      PKR_VAR_image_tag: prod-${{ github.event.release.tag_name }}
       PKR_VAR_vultr_api_key: ${{ secrets.VULTR_API_KEY }}
       HCP_CLIENT_ID: ${{ secrets.HCP_CLIENT_ID }}
       HCP_CLIENT_SECRET: ${{ secrets.HCP_CLIENT_SECRET }}


### PR DESCRIPTION
Updated the `create_prod_snapshot` workflow to use the release tag name for the image tag instead of the pull request number. This ensures that the image tags are more accurately associated with their respective releases.