### PR TITLE
Fix conditional logic in delete test snapshots workflow

### DIFF
--- a/.github/workflows/delete-test-snapshots-on-pr-merge.yml
+++ b/.github/workflows/delete-test-snapshots-on-pr-merge.yml
@@ -32,6 +32,7 @@ jobs:
           if [[ $snapshot_count -le 1 ]]; then
             echo "No snapshots to delete, or only one snapshot found."
             exit 0
+          fi
 
       - name: Sort snapshots by timestamp
         id: sort_snapshots


### PR DESCRIPTION
Add a missing 'fi' to correctly close the conditional block that checks the snapshot count. This prevents the workflow from failing when there are no snapshots to delete or only one snapshot found.