### PR TITLE
Fix string interpolation in delete snapshots script

### DIFF
--- a/.github/workflows/delete-test-snapshots-on-pr-merge.yml
+++ b/.github/workflows/delete-test-snapshots-on-pr-merge.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Delete all but the most recent snapshot
         run: |
           echo '${{ steps.prepare_snapshots_for_deletion.outputs.snapshots_to_delete }}' | jq -c '.[]' | while IFS= read -r snapshot; do
-            snapshot_id=$(echo '$snapshot' | jq -r '.id')
-            snapshot_desc=$(echo '$snapshot' | jq -r '.description')
+            snapshot_id=$(echo "$snapshot" | jq -r '.id')
+            snapshot_desc=$(echo "$snapshot" | jq -r '.description')
 
             curl -s -X DELETE -H "$AUTH_HEADER" "$VULTR_API_URL/$snapshot_id"
             echo "Deleted snapshot: $snapshot_desc ($snapshot_id)"


### PR DESCRIPTION
Corrects the use of double quotes for string interpolation in the workflow script. This change ensures the snapshot ID and description are properly parsed before deletion.