### PR TITLE
Add Docker repo check and start Docker service

### DIFF
--- a/vultr/ansible/playbook.yml
+++ b/vultr/ansible/playbook.yml
@@ -19,8 +19,14 @@
         state: present
         create_home: yes
 
+    - name: Check if Docker repository is already present
+      ansible.builtin.stat:
+        path: /etc/yum.repos.d/docker-ce.repo
+      register: docker_repo
+
     - name: Add Docker repo
       ansible.builtin.command: dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+      when: not docker_repo.stat.exists
 
     - name: Install Docker
       ansible.builtin.yum:
@@ -36,4 +42,4 @@
       ansible.builtin.systemd:
         name: docker
         enabled: yes
-        state: stopped
+        state: started


### PR DESCRIPTION
Check if Docker repository already exists before adding it to avoid redundancy. Set Docker service to start after installation instead of stopping it.