### PR TITLE
Fix snapshot deletion logic in GitHub Action

### DIFF
--- a/.github/workflows/delete-test-snapshots-on-pr-merge.yml
+++ b/.github/workflows/delete-test-snapshots-on-pr-merge.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Delete all but the most recent snapshot
         run: |
-          echo '${{ steps.sort_snapshots.outputs.snapshots_sorted }}' | jq -c '.[1:]' | while IFS= read -r snapshot; do
+          echo '${{ steps.sort_snapshots.outputs.snapshots_sorted }}' | jq -c '.[1:][]' | while IFS= read -r snapshot; do
             snapshot_id=$(echo "$snapshot" | jq -r '.id')
             snapshot_desc=$(echo "$snapshot" | jq -r '.description')
 


### PR DESCRIPTION
Modify the command to correctly iterate over snapshots in the workflow. This ensures all but the most recent snapshots are properly processed for deletion.