### PR TITLE
Harden SSH security settings

### DIFF
--- a/vultr/ansible/playbook.yml
+++ b/vultr/ansible/playbook.yml
@@ -13,20 +13,6 @@
         state: latest
         update_cache: yes
 
-    - name: Disable PermitRootLogin with password
-      ansible.builtin.lineinfile:
-        path: /etc/ssh/sshd_config
-        regexp: '^PermitRootLogin yes'
-        line: 'PermitRootLogin without-password'
-        state: present
-
-    - name: Ensure PasswordAuthentication is disabled for root
-      ansible.builtin.lineinfile:
-        path: /etc/ssh/sshd_config
-        regexp: '^#?PasswordAuthentication'
-        line: 'PasswordAuthentication no'
-        state: present
-
     - name: Ensure /etc/ssh/sshd_config.d directory exists
       ansible.builtin.file:
         path: /etc/ssh/sshd_config.d
@@ -39,6 +25,7 @@
         dest: /etc/ssh/sshd_config.d/00-disable-ssh-password.conf
         content: |
           PasswordAuthentication no
+          ChallengeResponseAuthentication no
         owner: root
         group: root
         mode: '0644'

--- a/vultr/ansible/playbook.yml
+++ b/vultr/ansible/playbook.yml
@@ -27,10 +27,12 @@
         line: 'PasswordAuthentication no'
         state: present
 
-    - name: Ensure 50-cloud-init.conf is removed
-      ansible.builtin.file:
+    - name: Ensure PasswordAuthentication is disabled for root
+      ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config.d/50-cloud-init.conf
-        state: absent
+        regexp: '^PasswordAuthentication yes'
+        line: 'PasswordAuthentication no'
+        state: present
 
     - name: Check if Docker repository is already present
       ansible.builtin.stat:

--- a/vultr/ansible/playbook.yml
+++ b/vultr/ansible/playbook.yml
@@ -30,28 +30,18 @@
     - name: Ensure /etc/cloud/cloud.cfg.d directory exists
       ansible.builtin.file:
         path: /etc/cloud/cloud.cfg.d
-        state: directory
         owner: root
         group: root
         mode: '0755'
 
     - name: Create or update cloud-init configuration to disable SSH
       ansible.builtin.copy:
-        dest: /etc/cloud/cloud.cfg.d/99-disable-cloud-init-ssh.conf
+        dest: /etc/cloud/cloud.cfg.d/00-disable-ssh-password.conf
         content: |
-          # Disable cloud-init's SSH management
-          ssh_deletekeys: 0
-          ssh_genkeytypes: []
-          disable_root: 0
-          ssh_pwauth: 0
+          PasswordAuthentication no
         owner: root
         group: root
         mode: '0644'
-
-    - name: Remove cloud-init SSH config to prevent overriding
-      ansible.builtin.file:
-        path: /etc/ssh/sshd_config.d/50-cloud-init.conf
-        state: absent
 
     - name: Check if Docker repository is already present
       ansible.builtin.stat:

--- a/vultr/ansible/playbook.yml
+++ b/vultr/ansible/playbook.yml
@@ -27,6 +27,12 @@
         line: 'PasswordAuthentication no'
         state: present
 
+    - name: Ensure /etc/cloud/cloud.cfg.d directory exists
+      file:
+        path: /etc/cloud/cloud.cfg.d
+        state: directory
+        mode: '0755'
+
     - name: Create or update cloud-init configuration to disable SSH
       ansible.builtin.blockinfile:
         path: /etc/cloud/cloud.cfg.d/99-disable-cloud-init-ssh.conf

--- a/vultr/ansible/playbook.yml
+++ b/vultr/ansible/playbook.yml
@@ -27,16 +27,16 @@
         line: 'PasswordAuthentication no'
         state: present
 
-    - name: Ensure /etc/cloud/cloud.cfg.d directory exists
+    - name: Ensure /etc/ssh/sshd_config.d directory exists
       ansible.builtin.file:
-        path: /etc/cloud/cloud.cfg.d
+        path: /etc/ssh/sshd_config.d
         owner: root
         group: root
         mode: '0755'
 
-    - name: Create or update cloud-init configuration to disable SSH
+    - name: Add override file to disable SSH password login
       ansible.builtin.copy:
-        dest: /etc/cloud/cloud.cfg.d/00-disable-ssh-password.conf
+        dest: /etc/ssh/sshd_config.d/00-disable-ssh-password.conf
         content: |
           PasswordAuthentication no
         owner: root

--- a/vultr/ansible/playbook.yml
+++ b/vultr/ansible/playbook.yml
@@ -27,12 +27,19 @@
         line: 'PasswordAuthentication no'
         state: present
 
-    - name: Ensure PasswordAuthentication is disabled for root
-      ansible.builtin.lineinfile:
+    - name: Create or update cloud-init configuration to disable SSH
+      ansible.builtin.blockinfile:
+        path: /etc/cloud/cloud.cfg.d/99-disable-cloud-init-ssh.conf
+        block: |
+          ssh_deletekeys:   0
+          ssh_genkeytypes:  []
+          disable_root:     0
+          ssh_pwauth:       0
+
+    - name: Remove cloud-init SSH config to prevent overriding
+      ansible.builtin.file:
         path: /etc/ssh/sshd_config.d/50-cloud-init.conf
-        regexp: '^PasswordAuthentication yes'
-        line: 'PasswordAuthentication no'
-        state: present
+        state: absent
 
     - name: Check if Docker repository is already present
       ansible.builtin.stat:

--- a/vultr/ansible/playbook.yml
+++ b/vultr/ansible/playbook.yml
@@ -13,6 +13,25 @@
         state: latest
         update_cache: yes
 
+    - name: Disable PermitRootLogin with password
+      ansible.builtin.lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: '^PermitRootLogin yes'
+        line: 'PermitRootLogin without-password'
+        state: present
+
+    - name: Ensure PasswordAuthentication is disabled for root
+      ansible.builtin.lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: '^#?PasswordAuthentication'
+        line: 'PasswordAuthentication no'
+        state: present
+
+    - name: Ensure 50-cloud-init.conf is removed
+      ansible.builtin.file:
+        path: /etc/ssh/sshd_config.d/50-cloud-init.conf
+        state: absent
+
     - name: Check if Docker repository is already present
       ansible.builtin.stat:
         path: /etc/yum.repos.d/docker-ce.repo

--- a/vultr/ansible/playbook.yml
+++ b/vultr/ansible/playbook.yml
@@ -28,19 +28,25 @@
         state: present
 
     - name: Ensure /etc/cloud/cloud.cfg.d directory exists
-      file:
+      ansible.builtin.file:
         path: /etc/cloud/cloud.cfg.d
         state: directory
+        owner: root
+        group: root
         mode: '0755'
 
     - name: Create or update cloud-init configuration to disable SSH
-      ansible.builtin.blockinfile:
-        path: /etc/cloud/cloud.cfg.d/99-disable-cloud-init-ssh.conf
-        block: |
-          ssh_deletekeys:   0
-          ssh_genkeytypes:  []
-          disable_root:     0
-          ssh_pwauth:       0
+      ansible.builtin.copy:
+        dest: /etc/cloud/cloud.cfg.d/99-disable-cloud-init-ssh.conf
+        content: |
+          # Disable cloud-init's SSH management
+          ssh_deletekeys: 0
+          ssh_genkeytypes: []
+          disable_root: 0
+          ssh_pwauth: 0
+        owner: root
+        group: root
+        mode: '0644'
 
     - name: Remove cloud-init SSH config to prevent overriding
       ansible.builtin.file:


### PR DESCRIPTION
Disable root login with password and password authentication in SSH. Remove 50-cloud-init.conf to prevent configuration override in sshd.