### PR TITLE
Add Terraform run trigger to workflow for PRs

### DIFF
--- a/.github/workflows/create-prod-snapshot-on-release.yml
+++ b/.github/workflows/create-prod-snapshot-on-release.yml
@@ -17,6 +17,7 @@ jobs:
       HCP_PROJECT_ID: ${{ secrets.HCP_PROJECT_ID }}
       HCP_PKR_BUCKET: discord-bot-server
       HCP_PKR_CHANNEL: production
+      HCP_TF_API_TOKEN: ${{ secrets.HCP_TF_API_TOKEN }}
 
     steps:
       - name: Checkout code
@@ -75,3 +76,45 @@ jobs:
               "version_fingerprint": "'"${{ steps.packer_build.outputs.version_fingerprint }}"'",
               "update_mask": "versionFingerprint"
             }'
+
+      - name: Get workspace ID by name
+        id: get_workspace_id
+        run: |
+          workspace_id=$(curl -s -X GET \
+            --header "Authorization: Bearer $HCP_TF_API_TOKEN" \
+            --header "Content-Type: application/vnd.api+json" \
+            "https://app.terraform.io/api/v2/organizations/madcow234/workspaces?search%5Bname%5D=discord-bot-server-staging" | jq -r '.data[0].id')
+          if [[ -z "$workspace_id" ]]; then
+            echo "Error: Unable to retrieve workspace ID"
+            exit 1
+          else
+            echo "workspace_id=$workspace_id" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Trigger HCP Terraform run
+        run: |
+          curl -X POST \
+            --header "Authorization: Bearer $HCP_TF_API_TOKEN" \
+            --header "Content-Type: application/vnd.api+json" \
+            https://app.terraform.io/api/v2/runs \
+            -d '{
+              "data": {
+                "attributes": {
+                  "is-destroy": false,
+                  "auto-apply": true
+                },
+                "type": "runs",
+                "relationships": {
+                  "workspace": {
+                    "data": {
+                      "type": "workspaces",
+                      "id": "'"${{ steps.get_workspace_id.outputs.workspace_id }}"'"
+                    }
+                  }
+                }
+              }
+            }'
+          if [[ $? -ne 0 ]]; then
+            echo "Error: Unable to trigger workspace run"
+            exit 1
+          fi

--- a/.github/workflows/create-test-snapshot-on-pr.yml
+++ b/.github/workflows/create-test-snapshot-on-pr.yml
@@ -20,6 +20,7 @@ jobs:
       HCP_PROJECT_ID: ${{ secrets.HCP_PROJECT_ID }}
       HCP_PKR_BUCKET: discord-bot-server
       HCP_PKR_CHANNEL: testing
+      HCP_TF_API_TOKEN: ${{ secrets.HCP_TF_API_TOKEN }}
 
     steps:
       - name: Checkout code
@@ -78,3 +79,45 @@ jobs:
               "version_fingerprint": "'"${{ steps.packer_build.outputs.version_fingerprint }}"'",
               "update_mask": "versionFingerprint"
             }'
+
+      - name: Get workspace ID by name
+        id: get_workspace_id
+        run: |
+          workspace_id=$(curl -s -X GET \
+            --header "Authorization: Bearer $HCP_TF_API_TOKEN" \
+            --header "Content-Type: application/vnd.api+json" \
+            "https://app.terraform.io/api/v2/organizations/madcow234/workspaces?search%5Bname%5D=discord-bot-server-image-testing" | jq -r '.data[0].id')
+          if [[ -z "$workspace_id" ]]; then
+            echo "Error: Unable to retrieve workspace ID"
+            exit 1
+          else
+            echo "workspace_id=$workspace_id" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Trigger HCP Terraform run
+        run: |
+          curl -X POST \
+            --header "Authorization: Bearer $HCP_TF_API_TOKEN" \
+            --header "Content-Type: application/vnd.api+json" \
+            https://app.terraform.io/api/v2/runs \
+            -d '{
+              "data": {
+                "attributes": {
+                  "is-destroy": false,
+                  "auto-apply": true
+                },
+                "type": "runs",
+                "relationships": {
+                  "workspace": {
+                    "data": {
+                      "type": "workspaces",
+                      "id": "'"${{ steps.get_workspace_id.outputs.workspace_id }}"'"
+                    }
+                  }
+                }
+              }
+            }'
+          if [[ $? -ne 0 ]]; then
+            echo "Error: Unable to trigger workspace run"
+            exit 1
+          fi

--- a/.github/workflows/delete-test-snapshots-on-pr-merge.yml
+++ b/.github/workflows/delete-test-snapshots-on-pr-merge.yml
@@ -12,11 +12,11 @@ jobs:
     defaults:
       run:
         shell: bash
-
     env:
       VULTR_API_URL: https://api.vultr.com/v2/snapshots
       AUTH_HEADER: "Authorization: Bearer ${{ secrets.VULTR_API_KEY }}"
       SNAPSHOT_DESCRIPTION: Discord Bot Server [test-PR#${{ github.event.pull_request.number }}]
+      HCP_TF_API_TOKEN: ${{ secrets.HCP_TF_API_TOKEN }}
 
     steps:
       - name: Fetch snapshots for this PR
@@ -50,3 +50,45 @@ jobs:
             echo "Deleted snapshot: $snapshot_desc ($snapshot_id)"
           done
           echo "Kept the most recent snapshot."
+
+      - name: Get workspace ID by name
+        id: get_workspace_id
+        run: |
+          workspace_id=$(curl -s -X GET \
+            --header "Authorization: Bearer $HCP_TF_API_TOKEN" \
+            --header "Content-Type: application/vnd.api+json" \
+            "https://app.terraform.io/api/v2/organizations/madcow234/workspaces?search%5Bname%5D=discord-bot-server-image-testing" | jq -r '.data[0].id')
+          if [[ -z "$workspace_id" ]]; then
+            echo "Error: Unable to retrieve workspace ID"
+            exit 1
+          else
+            echo "workspace_id=$workspace_id" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Trigger HCP Terraform run
+        run: |
+          curl -X POST \
+            --header "Authorization: Bearer $HCP_TF_API_TOKEN" \
+            --header "Content-Type: application/vnd.api+json" \
+            https://app.terraform.io/api/v2/runs \
+            -d '{
+              "data": {
+                "attributes": {
+                  "is-destroy": true,
+                  "auto-apply": true
+                },
+                "type": "runs",
+                "relationships": {
+                  "workspace": {
+                    "data": {
+                      "type": "workspaces",
+                      "id": "'"${{ steps.get_workspace_id.outputs.workspace_id }}"'"
+                    }
+                  }
+                }
+              }
+            }'
+          if [[ $? -ne 0 ]]; then
+            echo "Error: Unable to trigger workspace run"
+            exit 1
+          fi


### PR DESCRIPTION
This commit adds steps to the `create-test-snapshot-on-pr.yml` workflow to trigger a Terraform run using HCP_TF_API_TOKEN for authentication. The workflow now retrieves the workspace ID and triggers a run in the specified Terraform workspace. This ensures the infrastructure changes are applied automatically during the PR process.